### PR TITLE
For Quarkus 3.0, Services that call a repository should be transactio…

### DIFF
--- a/app/src/main/java/org/lfenergy/compas/sitipe/rest/exception/WebApplicationExceptionHandler.java
+++ b/app/src/main/java/org/lfenergy/compas/sitipe/rest/exception/WebApplicationExceptionHandler.java
@@ -1,0 +1,22 @@
+package org.lfenergy.compas.sitipe.rest.exception;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Provider
+public class WebApplicationExceptionHandler implements ExceptionMapper<WebApplicationException> {
+    @Override
+    public Response toResponse(WebApplicationException e) {
+        final Map<String, String> response = new HashMap<>();
+        response.put("message", e.getMessage());
+        return Response.status(e.getResponse().getStatus())
+                .entity(response)
+                .build();
+    }
+}
+

--- a/app/src/test/java/org/lfenergy/compas/sitipe/rest/v2/BTComponentResourceTest.java
+++ b/app/src/test/java/org/lfenergy/compas/sitipe/rest/v2/BTComponentResourceTest.java
@@ -95,12 +95,13 @@ class BTComponentResourceTest extends BaseIntegrationTest {
         var response = given()
                 .when().get("/imported/{id}", 10)
                 .then()
-                .statusCode(500)
+                .statusCode(404)
                 .extract()
                 .response();
 
+
         JsonPath jsonPath = response.jsonPath();
 
-        assertEquals("CORE-9999", ((LinkedHashMap<String, ?>)((ArrayList)((LinkedHashMap<String, ?>)jsonPath.get()).get("errorMessages")).get(0)).get("code"));
+        assertEquals("Imported BT Component not found", jsonPath.getString("message"));
     }
 }

--- a/service/src/main/java/org/lfenergy/compas/sitipe/service/BTComponentService.java
+++ b/service/src/main/java/org/lfenergy/compas/sitipe/service/BTComponentService.java
@@ -4,6 +4,7 @@
 
 package org.lfenergy.compas.sitipe.service;
 
+import jakarta.transaction.Transactional;
 import org.lfenergy.compas.sitipe.data.repository.BTComponentRepository;
 import org.lfenergy.compas.sitipe.dto.BTComponentDTO;
 
@@ -23,6 +24,7 @@ public class BTComponentService {
         this.btComponentRepository = btComponentRepository;
     }
 
+    @Transactional
     public List<BTComponentDTO> getBTComponentsByBayTypicalAccessId(final String accessId) {
         return btComponentRepository.findBayTypicalComponentsByTypicalAccessId(accessId)
             .stream()

--- a/service/src/main/java/org/lfenergy/compas/sitipe/service/BayTypicalService.java
+++ b/service/src/main/java/org/lfenergy/compas/sitipe/service/BayTypicalService.java
@@ -4,6 +4,7 @@
 
 package org.lfenergy.compas.sitipe.service;
 
+import jakarta.transaction.Transactional;
 import org.lfenergy.compas.sitipe.SitipeProperties;
 import org.lfenergy.compas.sitipe.data.repository.BayTypicalRepository;
 import org.lfenergy.compas.sitipe.data.repository.SystemVersionRepository;
@@ -33,6 +34,7 @@ public class BayTypicalService {
         this.sitipeProperties = sitipeProperties;
     }
 
+    @Transactional
     public List<BayTypicalDTO> getAssignedBayTypicals() {
         return this.systemVersionRepository.findByVersion(sitipeProperties.version())
             .stream()

--- a/service/src/main/java/org/lfenergy/compas/sitipe/service/ImportedComponentService.java
+++ b/service/src/main/java/org/lfenergy/compas/sitipe/service/ImportedComponentService.java
@@ -35,6 +35,7 @@ public class ImportedComponentService {
         this.importedComponentRepository = importedComponentRepository;
     }
 
+    @Transactional
     public List<ImportedComponentDTO> getByAccessId(final String accessId) {
         return importedComponentRepository.getByAccessId(accessId)
             .stream()
@@ -42,6 +43,7 @@ public class ImportedComponentService {
             .toList();
     }
 
+    @Transactional
     public ImportedDataDTO getImportedComponentData(final Integer id) {
         final ImportedComponent importedComponent = this.getEntity(id);
 


### PR DESCRIPTION
Added the `@transactional` annotation to Service functions
Added a ExceptionHandler, since this has changed in Quarkus 3.0